### PR TITLE
Modify emu3_preset_zone, parameters_a2[2] is lfo_rate and lfo_delay, …

### DIFF
--- a/src/emu3bm.c
+++ b/src/emu3bm.c
@@ -119,7 +119,18 @@ struct emu3_preset_zone
   char vca_pan;
   unsigned char vcf_type_lfo_shape;
   unsigned char end1;		//0xff
-  unsigned char end2;		//0x01
+  // The settings 'chorus (off/on)', 'disable loop (off/on)', 'disable side (off/left/right)'
+  // are encoded into a single byte. There unused bits are unknown, they could mean something.
+  //
+  //  1010 0000 = off, disable side right
+  //  1010 1000 = on, disable side right
+  //  0110 1000 = disable side left
+  //  |||  |
+  //  |||  ^chorus on = 1
+  //  ||^disable loop on = 1
+  //  |^disable left = 1
+  //  ^disable right
+  unsigned char chorus_disable_side_loop;
 };
 
 struct emu3_preset

--- a/src/emu3bm.c
+++ b/src/emu3bm.c
@@ -502,7 +502,8 @@ emu3_str_to_emu3name (const char *src)
 static void
 emu3_cpystr (char *dst, const char *src)
 {
-  int len = strlen (src);
+  size_t len = strlen(src);
+  if (len > NAME_SIZE) len = NAME_SIZE;
 
   memcpy (dst, src, NAME_SIZE);
   memset (&dst[len], ' ', NAME_SIZE - len);

--- a/src/emu3bm.c
+++ b/src/emu3bm.c
@@ -115,7 +115,7 @@ struct emu3_preset_zone
   char vca_level;
   char unknown_1;
   char vcf_tracking;
-  char unknown_3;
+  unsigned char note_on_delay; // 0x00 to 0xFF for 0.00 to 1.53s
   char vca_pan;
   unsigned char vcf_type_lfo_shape;
   unsigned char end1;		//0xff
@@ -370,6 +370,12 @@ emu3_get_time_21_69( unsigned char index )
   return 0.0f;
 }
 
+float
+emu3_get_note_on_delay( const unsigned char value )
+{
+  return (float)value * 0.006f;
+}
+
 static char *
 emu3_wav_filename_to_filename (const char *wav_file)
 {
@@ -454,6 +460,7 @@ emu3_print_preset_zone_info (struct emu_file *file,
   emu_print (1, 3, "Sample: %d\n",
 	     (zone->sample_id_msb << 8) + zone->sample_id_lsb);
   emu_print (1, 3, "Original note: %s\n", NOTE_NAMES[zone->root_note]);
+  emu_print (1, 3, "Note On delay: %.2fs\n", emu3_get_note_on_delay(zone->note_on_delay) );
   emu_print (1, 3, "VCA level: %d\n",
 	     emu3_get_percent_value (zone->vca_level));
   emu_print (1, 3, "VCA pan: %d\n", emu3_get_percent_value_signed (zone->vca_pan));
@@ -1481,11 +1488,11 @@ emu3_add_preset_zone (struct emu_file *file, int preset_num, int sample_num,
   zone->vca_level = 0x7f;
   zone->unknown_1 = 0;
   zone->vcf_tracking = 0x40;
-  zone->unknown_3 = 0;
+  zone->note_on_delay = 0;
   zone->vca_pan = 0x40;
   zone->vcf_type_lfo_shape = 0x8;
   zone->end1 = 0xff;
-  zone->end2 = 0x01;
+  zone->chorus_disable_side_loop = 0x01;
 
   bank->next_preset += inc_size;
   file->fsize += inc_size;

--- a/src/emu3bm.c
+++ b/src/emu3bm.c
@@ -113,7 +113,7 @@ struct emu3_preset_zone
   char lfo_to_cutoff;
   char lfo_to_pan;
   char vca_level;
-  char unknown_1;
+  char note_tuning; // -64 to 64 for -100cents to 100cents
   char vcf_tracking;
   unsigned char note_on_delay; // 0x00 to 0xFF for 0.00 to 1.53s
   char vca_pan;
@@ -376,6 +376,13 @@ emu3_get_note_on_delay( const unsigned char value )
   return (float)value * 0.006f;
 }
 
+// [-64, 0, +64] to -100, 0, 100
+float
+emu3_get_note_tuning( const char value )
+{
+  return (float)value * 1.5625f;
+}
+
 static char *
 emu3_wav_filename_to_filename (const char *wav_file)
 {
@@ -460,7 +467,8 @@ emu3_print_preset_zone_info (struct emu_file *file,
   emu_print (1, 3, "Sample: %d\n",
 	     (zone->sample_id_msb << 8) + zone->sample_id_lsb);
   emu_print (1, 3, "Original note: %s\n", NOTE_NAMES[zone->root_note]);
-  emu_print (1, 3, "Note On delay: %.2fs\n", emu3_get_note_on_delay(zone->note_on_delay) );
+  emu_print (1, 3, "Note tuning: %.1fcents\n", emu3_get_note_tuning(zone->note_tuning) );
+  emu_print (1, 3, "Note On delay: %.3fs\n", emu3_get_note_on_delay(zone->note_on_delay) );
   emu_print (1, 3, "VCA level: %d\n",
 	     emu3_get_percent_value (zone->vca_level));
   emu_print (1, 3, "VCA pan: %d\n", emu3_get_percent_value_signed (zone->vca_pan));
@@ -1486,7 +1494,7 @@ emu3_add_preset_zone (struct emu_file *file, int preset_num, int sample_num,
   zone->lfo_to_cutoff = 0;
   zone->lfo_to_pan = 0;
   zone->vca_level = 0x7f;
-  zone->unknown_1 = 0;
+  zone->note_tuning = 0;
   zone->vcf_tracking = 0x40;
   zone->note_on_delay = 0;
   zone->vca_pan = 0x40;

--- a/src/emu3bm.c
+++ b/src/emu3bm.c
@@ -489,7 +489,7 @@ emu3_print_preset_zone_info (struct emu_file *file,
   if (strcmp (ESI_32_V3_DEF, bank->format) == 0)
     q = q - 0x80;
 
-  emu_print (1, 3, "VCF Q: %d\n", q);
+  emu_print (1, 3, "VCF Q: %d\n", emu3_get_percent_value(q) );
 
   emu_print (1, 3, "VCF envelope amount: %d\n",
 	     emu3_get_percent_value (zone->vcf_envelope_amount));


### PR DESCRIPTION
…unknown_2 is vcf_tracking. Fix emu3_get_percent_value() to match the values on the unit itself. Add table for percentage (-100, +100) as used by VCA pan, Add table for LFO rate, VCF cutoff frequency, 163.69 times, 21.69 times. Add methods to lookup values from these tables. Add method to translate byte to VCF tracking value. Modify -vvv output to show all these values.